### PR TITLE
chore(linter): unit tests and eslint config

### DIFF
--- a/common/.eslintrc.json
+++ b/common/.eslintrc.json
@@ -32,6 +32,9 @@
 
   "rules": {
     "no-unused-vars": 0,
+    // @if typescript
+    "@typescript-eslint/no-unused-vars": 0,
+    // @endif
     "no-prototype-builtins": 0,
     "no-console": 0,
     "getter-return": 0

--- a/scaffold-navigation/test__if_karma_or_jest/unit/app.spec.ext
+++ b/scaffold-navigation/test__if_karma_or_jest/unit/app.spec.ext
@@ -15,8 +15,8 @@ class RouterStub {
 }
 
 describe('the App module', () => {
-  var sut;
-  var mockedRouter;
+  let sut;
+  let mockedRouter;
 
   beforeEach(() => {
     mockedRouter = new RouterStub();

--- a/scaffold-navigation/test__if_karma_or_jest/unit/child-router.spec.ext
+++ b/scaffold-navigation/test__if_karma_or_jest/unit/child-router.spec.ext
@@ -15,8 +15,8 @@ class RouterStub {
 }
 
 describe('the Child Router module', () => {
-  var sut;
-  var mockedRouter;
+  let sut;
+  let mockedRouter;
 
   beforeEach(() => {
     mockedRouter = new RouterStub();

--- a/scaffold-navigation/test__if_karma_or_jest/unit__if_typescript/users.spec.ts
+++ b/scaffold-navigation/test__if_karma_or_jest/unit__if_typescript/users.spec.ts
@@ -10,7 +10,7 @@ class HttpStub {
     });
   }
   
-  configure(func) { }
+  configure(func) { /**/ }
 }
 
 function createHttpStub(): any {
@@ -20,10 +20,10 @@ function createHttpStub(): any {
 describe('the Users module', () => {
 
   it('sets fetch response to users', (done) => {
-    var http = createHttpStub(),
-        sut = new Users(<HttpClient>http),
-        itemStubs = [1],
-        itemFake = [2];
+    const http = createHttpStub(),
+      sut = new Users(<HttpClient>http),
+      itemStubs = [1],
+      itemFake = [2];
         
     http.items = itemStubs;
     


### PR DESCRIPTION
* turns the typescript specific no-unused-vars rule off
* some minor linter fixes for unit tests from the navigation skeleton