### PR TITLE
Update sourceMap path in launch.json for webpack5

### DIFF
--- a/vscode/.vscode/launch.json__if_webpack
+++ b/vscode/.vscode/launch.json__if_webpack
@@ -12,7 +12,7 @@
       "webRoot": "${workspaceRoot}/src",
       "userDataDir": "${workspaceRoot}/.chrome",
       "sourceMapPathOverrides": {
-        "webpack:///./src/*": "${webRoot}/*"
+        "webpack://${workspaceFolderBasename}/./src/*": "${webRoot}/*"
       }
     }
   ]


### PR DESCRIPTION
## What was done
- Because of the new sourceMap structure in webpack5, update the corresponding `launch.json` setting
![image](https://user-images.githubusercontent.com/30693990/155119745-a973b6f4-6b1c-4943-b253-d95035c26d9e.png)

- ⚠️ Big note, the user will have to manually change the `launch.json` setting, if their package is named eg. `@primedao/prime-xyz` to:
```json
      "sourceMapPathOverrides": {
        "webpack://@primedao/${workspaceFolderBasename}/./src/*": "${webRoot}/*"
      },
```
Also note, that in the browser "Sources" tab the `@` (at) symbol does not get printed, but still _needed_ in the mapping above
![image](https://user-images.githubusercontent.com/30693990/155120132-0eadcb13-d3a1-4b58-9fee-56e1d2dee675.png)


## Testing

1. Set breakpoint
2. Launch browser

#### Before
Did not trigger breakpoint

#### After
Should trigger breakpoint